### PR TITLE
fix: modification de la definition des colonnes de la table Personne

### DIFF
--- a/src/main/java/com/isn/quizplatform/model/Personne.java
+++ b/src/main/java/com/isn/quizplatform/model/Personne.java
@@ -1,5 +1,6 @@
 package com.isn.quizplatform.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,15 +12,20 @@ public class Personne {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    
+    @Column(name = "nom")
     private String nom;
 
+    @Column(name = "prenom")
     private String prenom;
 
+    @Column(name = "mail")
     private String mail;
 
+    @Column(name = "mdp")
     private String mdp;
 
+    @Column(name = "role")
     private int role;
 
     public Personne() {


### PR DESCRIPTION
On modifie cela juste pour être en accord avec toutes les tables, normalement, nous n'avons pas besoin de le mettre, mais nous le faisons pour faciliter la compréhension du code.